### PR TITLE
Fix grep filename prefix printing per line

### DIFF
--- a/grep/s21_grep.c
+++ b/grep/s21_grep.c
@@ -49,30 +49,24 @@ void s21Grep(Options* opt, int argc, char* argv[], char* buff) {
   if (opt->e) {
     snprintf(pattern, BUFF_SIZE, "%s", buff);
   }
-  int fileCount = 0;
-  if (argc - optind > 1) {
-    fileCount = 1;
-  }
+  int fileCount = (argc - optind > 1);
   for (int i = optind; i < argc; i++) {
-    if (fileCount && !opt->l) {
-      printf("%s:", argv[i]);
-    }
-    s21GrepFile(opt, pattern, argv[i]);
+    s21GrepFile(opt, pattern, argv[i], fileCount);
   }
 }
 
-void s21GrepFile(Options* opt, char* pattern, char* filename) {
+void s21GrepFile(Options* opt, char* pattern, char* filename, int fileCount) {
   regex_t re;
   int cflags = REG_EXTENDED;
   FILE* file;
   file = fopen(filename, "r");
   if (opt->i) {
-    cflags = REG_ICASE;
+    cflags = REG_ICASE | REG_EXTENDED;
   }
 
   if (file != NULL) {
     regcomp(&re, pattern, cflags);
-    outline(opt, file, re, filename);
+    outline(opt, file, re, filename, fileCount);
     regfree(&re);
     fclose(file);
   } else {
@@ -80,7 +74,7 @@ void s21GrepFile(Options* opt, char* pattern, char* filename) {
   }
 }
 
-void outline(Options* opt, FILE* fp, regex_t re, char* file) {
+void outline(Options* opt, FILE* fp, regex_t re, char* file, int fileCount) {
   char text[BUFF_SIZE] = {0};
   regmatch_t pmatch[1];
   int lineMatches = 0, nline = 1;
@@ -96,10 +90,13 @@ void outline(Options* opt, FILE* fp, regex_t re, char* file) {
     if (result == REG_NOMATCH && opt->v) {
       match = 1;
     }
-    if (match && !opt->l && !opt->c && opt->n) {
-      printf("%d:", nline);
-    }
     if (match && !opt->l && !opt->c) {
+      if (fileCount) {
+        printf("%s:", file);
+      }
+      if (opt->n) {
+        printf("%d:", nline);
+      }
       printf("%s", text);
     }
     lineMatches += match;

--- a/grep/s21_grep.h
+++ b/grep/s21_grep.h
@@ -15,7 +15,7 @@ typedef struct {
 
 void flagsParser(int argc, char* argv[], Options* opt, char* patternE);
 void s21Grep(Options* opt, int argc, char* argv[], char* buff);
-void s21GrepFile(Options* opt, char* pattern, char* filename);
-void outline(Options* opt, FILE* fp, regex_t re, char* file);
+void s21GrepFile(Options* opt, char* pattern, char* filename, int fileCount);
+void outline(Options* opt, FILE* fp, regex_t re, char* file, int fileCount);
 
 #endif  // _SRC_S21_GREP_H_


### PR DESCRIPTION
## Summary
- update `s21_grep` to prefix file name on every matched line
- pass `fileCount` flag to helper functions
- fix case-insensitive flag to preserve REG_EXTENDED

## Testing
- `bash grep/grep_test.sh`
- `bash cat/test_for_s21_cat.sh`


------
https://chatgpt.com/codex/tasks/task_e_683f4661d8b88329b416195780a29012